### PR TITLE
fix iD preset URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you use gradle as your build tool, The easiest way to get this data is to put
 task downloadPresets {
     doLast {
         def targetDir = "path/to/data" // <- the relative path to the directory where the data should go
-        def presetsUrl = new URL("https://raw.githubusercontent.com/openstreetmap/iD/master/data/presets/presets.json")
+        def presetsUrl = new URL("https://raw.githubusercontent.com/openstreetmap/iD/release/data/presets/presets.json")
         def contentsUrl = new URL("https://api.github.com/repos/openstreetmap/iD/contents/dist/locales")
 
         new File("$targetDir/presets.json").withOutputStream { it << presetsUrl.openStream() }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It's in the JCenter repository, not Maven Central.
 
 ### Get the data
 
-The data for the dictionary is not maintained in this repository. It actually uses the [preset data from iD](https://github.com/openstreetmap/iD/blob/master/data/presets/presets.json) and [the translations of the presets](https://github.com/openstreetmap/iD/tree/master/dist/locales). The former can just be copied, the latter must be fished out of the global localization files for iD.
+The data for the dictionary is not maintained in this repository. It actually uses the [preset data from iD](https://raw.githubusercontent.com/openstreetmap/iD/release/data/presets/presets.json) and [the translations of the presets](https://github.com/openstreetmap/iD/tree/master/dist/locales). The former can just be copied, the latter must be fished out of the global localization files for iD.
 Do not forget to give attribution to iD since you are using their data.
 
 If you use gradle as your build tool, The easiest way to get this data is to put this task into your `build.gradle` and either execute this task manually from time to time or make the build process depend on it (by adding `preBuild.dependsOn(downloadPresets)`):


### PR DESCRIPTION
The iD repo does not have a master branch. I propose to suggest the release branch in the readme example.