### PR TITLE
support preset name placeholders (fixes #15)

### DIFF
--- a/library/src/test/java/de/westnordost/osmfeatures/IDPresetsTranslationJsonParserTest.java
+++ b/library/src/test/java/de/westnordost/osmfeatures/IDPresetsTranslationJsonParserTest.java
@@ -47,6 +47,26 @@ public class IDPresetsTranslationJsonParserTest {
         assertTrue(feature.getTerms().isEmpty());
     }
 
+    @Test public void load_features_and_localization_with_placeholder_name()
+    {
+        List<LocalizedFeature> features = parse("one_preset_with_placeholder_name.json", "localizations.json");
+
+        Map<String, LocalizedFeature> featuresById = new HashMap<>();
+        for (LocalizedFeature feature : features) {
+            featuresById.put(feature.getId(), feature);
+        }
+
+        assertEquals(2, features.size());
+        Feature feature = featuresById.get("some/id-dingsdongs");
+
+        assertEquals("some/id-dingsdongs", feature.getId());
+        assertEquals(mapOf(tag("a","b"), tag("c","d")), feature.getTags());
+        assertEquals(listOf(GeometryType.POINT), feature.getGeometry());
+        assertEquals("bar", feature.getName());
+        assertEquals(listOf("bar", "one", "two", "three"), feature.getNames());
+        assertEquals(listOf("a", "b"), feature.getTerms());
+    }
+
     @Test public void parse_some_real_data() throws IOException
     {
         URL url = new URL("https://raw.githubusercontent.com/openstreetmap/id-tagging-schema/main/dist/presets.json");

--- a/library/src/test/resources/one_preset_with_placeholder_name.json
+++ b/library/src/test/resources/one_preset_with_placeholder_name.json
@@ -1,0 +1,11 @@
+{
+  "some/id": {
+    "tags": { "a": "x", "c": "y" },
+    "geometry": ["point"]
+  },
+  "some/id-dingsdongs": {
+    "name": "{some/id}",
+    "tags": { "a": "b", "c": "d" },
+    "geometry": ["point"]
+  }
+}


### PR DESCRIPTION
@tyrasd : So in the dist/presets.json, it then looks like that right?

<a href="https://github.com/westnordost/osmfeatures/compare/preset-name-placeholders?expand=1#diff-f98cb31c499bc471c550b6ce7ff27ffe824336a3709ca406171b377a9a764b38">library/src/test/resources/one_preset_with_placeholder_name.json</a>

```json
{
  "some/id": {
    "tags": { "a": "x", "c": "y" },
    "geometry": ["point"]
  },
  "some/id-dingsdongs": {
    "name": "{some/id}",
    "tags": { "a": "b", "c": "d" },
    "geometry": ["point"]
  }
}
```