### PR TITLE
Fallback for untranslated feature names

### DIFF
--- a/src/commonMain/kotlin/de/westnordost/osmfeatures/IDLocalizedFeatureCollection.kt
+++ b/src/commonMain/kotlin/de/westnordost/osmfeatures/IDLocalizedFeatureCollection.kt
@@ -85,7 +85,10 @@ private fun String.getLanguageComponents(): Sequence<String> = sequence {
     yield(this@getLanguageComponents)
 }
 
-/** If a localized feature has no names and fallbacks are available, apply those. */
+/** If a localized feature has no names or no terms and fallbacks are available, apply those. */
 private fun LocalizedFeature.withFallback(fallback: Feature?) =
-    if (names.isEmpty() && fallback?.names != null) copy(names = fallback.names)
-    else this
+    if (fallback == null) this
+    else copy(
+        names = names.ifEmpty { fallback.names },
+        terms = terms.ifEmpty { fallback.terms },
+    )

--- a/src/commonMain/kotlin/de/westnordost/osmfeatures/IDLocalizedFeatureCollection.kt
+++ b/src/commonMain/kotlin/de/westnordost/osmfeatures/IDLocalizedFeatureCollection.kt
@@ -43,7 +43,7 @@ internal class IDLocalizedFeatureCollection(
                 for (languageComponent in language.getLanguageComponents()) {
                     val features = getOrLoadLocalizedFeaturesList(languageComponent)
                     for (feature in features) {
-                        result[feature.id] = feature
+                        result[feature.id] = feature.withFallback(result[feature.id])
                     }
                 }
             } else {
@@ -84,3 +84,8 @@ private fun String.getLanguageComponents(): Sequence<String> = sequence {
     }
     yield(this@getLanguageComponents)
 }
+
+/** If a localized feature has no names and fallbacks are available, apply those. */
+private fun LocalizedFeature.withFallback(fallback: Feature?) =
+    if (names.isEmpty() && fallback?.names != null) copy(names = fallback.names)
+    else this

--- a/src/commonTest/kotlin/de/westnordost/osmfeatures/IDLocalizedFeatureCollectionTest.kt
+++ b/src/commonTest/kotlin/de/westnordost/osmfeatures/IDLocalizedFeatureCollectionTest.kt
@@ -104,9 +104,9 @@ class IDLocalizedFeatureCollectionTest {
             setOf("Backhusl", "Gullideckel", "Brückle"),
             austrianFeatures.map { it.name }.toSet()
         )
-        assertEquals("Backhusl", c.get("some/id", austria)?.name)
-        assertEquals("Gullideckel", c.get("another/id", austria)?.name)
-        assertEquals("Brückle", c.get("yet/another/id", austria)?.name)
+        assertEquals(listOf("Backhusl", "alias 1"), c.get("some/id", austria)?.names)
+        assertEquals(listOf("Gullideckel"), c.get("another/id", austria)?.names)
+        assertEquals(listOf("Brückle", "alias 2"), c.get("yet/another/id", austria)?.names)
         assertEquals(listOf("foo"), c.get("some/id", austria)?.terms)
         assertEquals(listOf("baz"), c.get("another/id", austria)?.terms)
         assertEquals(emptyList(), c.get("yet/another/id", austria)?.terms)

--- a/src/commonTest/kotlin/de/westnordost/osmfeatures/IDLocalizedFeatureCollectionTest.kt
+++ b/src/commonTest/kotlin/de/westnordost/osmfeatures/IDLocalizedFeatureCollectionTest.kt
@@ -97,6 +97,7 @@ class IDLocalizedFeatureCollectionTest {
         assertNull(c.get("yet/another/id", german))
 
         // merging de-AT and de
+        // this exercises the case where only `name` or only `terms` is translated
         val austria = listOf("de-AT")
         val austrianFeatures = c.getAll(austria)
         assertEquals(
@@ -106,6 +107,9 @@ class IDLocalizedFeatureCollectionTest {
         assertEquals("Backhusl", c.get("some/id", austria)?.name)
         assertEquals("Gullideckel", c.get("another/id", austria)?.name)
         assertEquals("Brückle", c.get("yet/another/id", austria)?.name)
+        assertEquals(listOf("foo"), c.get("some/id", austria)?.terms)
+        assertEquals(listOf("baz"), c.get("another/id", austria)?.terms)
+        assertEquals(emptyList(), c.get("yet/another/id", austria)?.terms)
 
         // merging scripts
         val cryllic = listOf("de-Cyrl")

--- a/src/commonTest/resources/localizations_de-AT.json
+++ b/src/commonTest/resources/localizations_de-AT.json
@@ -3,6 +3,9 @@
     "some/id": {
       "name": "Backhusl"
     },
+    "another/id": {
+      "terms": "baz"
+    },
     "yet/another/id": {
       "name": "Brückle"
     }

--- a/src/commonTest/resources/localizations_de-AT.json
+++ b/src/commonTest/resources/localizations_de-AT.json
@@ -7,7 +7,8 @@
       "terms": "baz"
     },
     "yet/another/id": {
-      "name": "Brückle"
+      "name": "Brückle",
+      "aliases": "alias 2"
     }
   }
 }}}

--- a/src/commonTest/resources/localizations_de.json
+++ b/src/commonTest/resources/localizations_de.json
@@ -1,10 +1,12 @@
 { "xx": { "presets" : {
   "presets": {
     "some/id": {
-      "name": "Bäckerei"
+      "name": "Bäckerei",
+      "terms": "foo"
     },
     "another/id": {
-      "name": "Gullideckel"
+      "name": "Gullideckel",
+      "terms": "bar"
     }
   }
 }}}

--- a/src/commonTest/resources/localizations_de.json
+++ b/src/commonTest/resources/localizations_de.json
@@ -2,6 +2,7 @@
   "presets": {
     "some/id": {
       "name": "Bäckerei",
+      "aliases": "alias 1",
       "terms": "foo"
     },
     "another/id": {


### PR DESCRIPTION
Some feature translations don't include a `name` (e.g. [en-NZ](https://github.com/openstreetmap/id-tagging-schema/blob/7a4de1fd4b1109de56d61614b8d52e6b605efdc0/dist/translations/en-NZ.json#L277-L279)). In `loadLocalizedFeatures` these would completely override features from previous languages, with `names` as an empty array, causing an exception in the `Feature.name` getter. This can crash the StreetComplete app in `getNameAndLocationLabel`.

This change uses fallback names from previously loaded languages (i.e. `null`, `"en"`, before `"en-NZ"`).

As a separate change it might be reasonable to fall back for untranslated `terms` too, but I'm not confident about ramifications of that.

I'm pretty new to OSM and Kotlin - let me know if I can change anything here or if I'd be better to make an issue and discuss first.