### PR TITLE
improve word splitter, also split in brands for search

### DIFF
--- a/src/commonMain/kotlin/de/westnordost/osmfeatures/FeatureDictionary.kt
+++ b/src/commonMain/kotlin/de/westnordost/osmfeatures/FeatureDictionary.kt
@@ -334,7 +334,7 @@ class FeatureDictionary internal constructor(
             FeatureTermIndex(emptyList()) { emptyList() }
         } else {
             FeatureTermIndex(brandFeatureCollection.getAll(countryCodes)) { feature ->
-                if (!feature.isSearchable) emptyList() else feature.canonicalNames
+                if (!feature.isSearchable) emptyList() else feature.getSearchableNames().toList()
             }
         }
 
@@ -448,9 +448,12 @@ private fun Feature.matches(geometry: GeometryType?): Boolean =
 private fun Feature.getSearchableNames(): Sequence<String> = sequence {
     if (!isSearchable) return@sequence
     yieldAll(canonicalNames)
+    val wordSeparator = "[\\-()\\[\\],.!?&+=/\\\\ ]+".toRegex()
     for (name in canonicalNames) {
-        if (name.contains(" ")) {
-            yieldAll(name.replace("[()]", "").split(" "))
+        for (boundary in wordSeparator.findAll(name)) {
+            if (boundary.range.endExclusive != 0) {
+                yield(name.substring(boundary.range.endExclusive))
+            }
         }
     }
 }


### PR DESCRIPTION
This makes it so that the startsWith also covers the entire rest of the string, not just the single word.

Brands are not always super simple and especially brands in foreign languages might not be understood by the user as to which parts on a sign are parts of the brand or just text. People may just only try to write parts of what they can actually input on their keyboard or know how to write.

This is not perfect since a proper word split requires a lot more look-ups than just checking for characters (e.g. dictionary lookup), see https://www.unicode.org/reports/tr29/tr29-37.html

however this is much better than before and should cover more cases inside the NSI.

Some examples:

The user might not be very well experienced with this chain and only search for `Casino` (which exists and is also from this chain), however `Le Petit Casino` as found in the NSI is more appropriate:

![image](https://github.com/user-attachments/assets/767469c7-91b6-4927-823d-12d50d63a099)

Similarly here:

![image](https://github.com/user-attachments/assets/2bf5fa28-5b72-4f51-9709-2e42d4bf5188)

The user might think this is a Lawson, but "Natural Lawson" has a separate NSI entry as well, which is now shown.

Additionally the user might not find what they are looking for due to differences in spelling (which they are not aware of in foreign languages) and might try searching for other words / parts of the brand